### PR TITLE
Fix elastic semaphore.

### DIFF
--- a/elastic_semaphore.go
+++ b/elastic_semaphore.go
@@ -8,6 +8,7 @@ type elasticSemaphore struct {
 	limit   int
 	counter int
 	cond    *sync.Cond
+	mu      *sync.Mutex
 }
 
 func newElasticSemaphore(limit int) *elasticSemaphore {
@@ -15,41 +16,56 @@ func newElasticSemaphore(limit int) *elasticSemaphore {
 		limit:   limit,
 		counter: limit,
 		cond:    sync.NewCond(&sync.Mutex{}),
+		mu:      &sync.Mutex{},
 	}
 }
 
 func (es *elasticSemaphore) wait() {
 	es.cond.L.Lock()
 	defer es.cond.L.Unlock()
-	if es.counter == 0 {
+WAIT:
+	es.mu.Lock()
+	if es.counter <= 0 {
+		es.mu.Unlock()
 		es.cond.Wait()
+		es.mu.Lock()
+		if es.counter > 0 {
+			es.counter--
+		} else {
+			es.mu.Unlock()
+			goto WAIT
+		}
+		es.mu.Unlock()
 		return
 	}
 	es.counter--
+	es.mu.Unlock()
 	return
 }
 
 func (es *elasticSemaphore) signal() {
-	es.cond.L.Lock()
-	defer es.cond.L.Unlock()
+	es.mu.Lock()
+	defer es.mu.Unlock()
 	if es.counter == 0 {
 		es.cond.Signal()
 	}
 	if es.limit >= es.counter+1 {
 		es.counter++
+	} else {
+		es.counter = es.limit
 	}
 }
 
 func (es *elasticSemaphore) incrementLimit(n int) int {
-	es.cond.L.Lock()
-	defer es.cond.L.Unlock()
+	es.mu.Lock()
+	defer es.mu.Unlock()
 
 	if n == 0 {
 		return es.limit
 	}
 
 	if n > 0 {
-		if es.counter == 0 {
+		if es.counter == 0 || (es.counter < 0 && es.counter+n > 0) {
 			es.cond.Signal()
 		}
 		es.counter += n
@@ -59,8 +75,8 @@ func (es *elasticSemaphore) incrementLimit(n int) int {
 		if newLimit < 1 {
 			newLimit = 1
 		}
-		if newLimit < es.counter {
-			es.counter = newLimit
+		if es.limit != newLimit {
+			es.counter = newLimit - (es.limit - es.counter)
 		}
 		es.limit = newLimit
 	}

--- a/elastic_semaphore_test.go
+++ b/elastic_semaphore_test.go
@@ -89,8 +89,8 @@ func TestElasticSemaphoreIncrementLimitPositiveWithBlocking(t *testing.T) {
 		t.Errorf("elasticSemaphore.incrementLimit should change the limit to %d, but it changes to %d.", limit+inc, newLimit)
 	}
 
-	if sem.counter != 1 {
-		t.Errorf("elasticSemaphore.incrementLimit should change the counter to %d, but it changes to %d.", 1, sem.counter)
+	if sem.counter != 0 {
+		t.Errorf("elasticSemaphore.incrementLimit should change the counter to %d, but it changes to %d.", 0, sem.counter)
 	}
 }
 

--- a/reporter.go
+++ b/reporter.go
@@ -47,6 +47,9 @@ func usage(previous, current *linuxproc.Stat) float64 {
 	n := current.CPUStatAll.Nice - previous.CPUStatAll.Nice
 	s := current.CPUStatAll.System - previous.CPUStatAll.System
 	i := current.CPUStatAll.Idle - previous.CPUStatAll.Idle
+	if u == 0 && n == 0 && s == 0 && i == 0 {
+		return 0.0
+	}
 
 	return (float64(u+n+s) / float64(u+n+s+i)) * 100
 }


### PR DESCRIPTION
https://github.com/monochromegane/kaburaya/pull/1 removes bottleneck.
But it breaks semaphore.
This pull request fixes it.

### Fix points

- The semaphore counter is changed by executing signal and incrementLimit even during a wait () block. Therefore, it should check the counter again after the block is released.
- When the limit value is negative with incrementLimit, the number of counters was 1 or 0.
Correctly, the number of counters should be the current limit minus the current number of counters.
- When the number of counters is negative, incrementLimit may cause the number of counters to be positive. In this case, it is necessary to release the block by a signal.

### Performance

The performance dose not change.

```
BenchmarkSemaphoreByChannel-8                    2000000               872 ns/op             112 B/op        2 allocs/op
BenchmarkSemaphoreByElasticSemaphore-8           1000000              1063 ns/op             224 B/op        6 allocs/op
```