### PR TITLE
Fix elastic semaphore mutex.

### DIFF
--- a/elastic_semaphore.go
+++ b/elastic_semaphore.go
@@ -5,71 +5,95 @@ import (
 )
 
 type elasticSemaphore struct {
-	limit   int
-	counter int
-	cond    *sync.Cond
-	mu      *sync.Mutex
+	limit      int
+	counter    int
+	mu         *sync.Mutex
+	waitChan   chan struct{}
+	signalChan chan struct{}
+	waiting    bool
 }
 
 func newElasticSemaphore(limit int) *elasticSemaphore {
 	return &elasticSemaphore{
-		limit:   limit,
-		counter: limit,
-		cond:    sync.NewCond(&sync.Mutex{}),
-		mu:      &sync.Mutex{},
+		limit:      limit,
+		counter:    limit,
+		mu:         &sync.Mutex{},
+		waitChan:   make(chan struct{}),
+		signalChan: make(chan struct{}),
+		waiting:    false,
 	}
 }
 
 func (es *elasticSemaphore) wait() {
-	es.cond.L.Lock()
-	defer es.cond.L.Unlock()
 WAIT:
 	es.mu.Lock()
 	if es.counter <= 0 {
+		es.counter--
+		es.waiting = true
 		es.mu.Unlock()
-		es.cond.Wait()
+		es.waitChan <- struct{}{}
+		<-es.signalChan
 		es.mu.Lock()
-		if es.counter > 0 {
-			es.counter--
-		} else {
+		if es.counter < 0 {
 			es.mu.Unlock()
 			goto WAIT
 		}
 		es.mu.Unlock()
 		return
 	}
+	es.waiting = false
 	es.counter--
 	es.mu.Unlock()
 	return
 }
 
 func (es *elasticSemaphore) signal() {
+WAIT:
 	es.mu.Lock()
-	defer es.mu.Unlock()
-	if es.counter == 0 {
-		es.cond.Signal()
+	doSignal := false
+	if es.waiting && es.counter == -1 {
+		select {
+		case <-es.waitChan:
+		default:
+			es.mu.Unlock()
+			goto WAIT
+		}
+		doSignal = true
 	}
 	if es.limit >= es.counter+1 {
 		es.counter++
 	} else {
 		es.counter = es.limit
 	}
+	if doSignal {
+		es.signalChan <- struct{}{}
+	}
+	es.mu.Unlock()
 }
 
 func (es *elasticSemaphore) incrementLimit(n int) int {
-	es.mu.Lock()
-	defer es.mu.Unlock()
-
 	if n == 0 {
 		return es.limit
 	}
 
+WAIT:
+	es.mu.Lock()
 	if n > 0 {
-		if es.counter == 0 || (es.counter < 0 && es.counter+n > 0) {
-			es.cond.Signal()
+		doSignal := false
+		if es.waiting && (es.counter == -1 || (es.counter < 0 && es.counter+n > 0)) {
+			select {
+			case <-es.waitChan:
+			default:
+				es.mu.Unlock()
+				goto WAIT
+			}
+			doSignal = true
 		}
 		es.counter += n
 		es.limit += n
+		if doSignal {
+			es.signalChan <- struct{}{}
+		}
 	} else {
 		newLimit := es.limit + n
 		if newLimit < 1 {
@@ -80,5 +104,6 @@ func (es *elasticSemaphore) incrementLimit(n int) int {
 		}
 		es.limit = newLimit
 	}
+	defer es.mu.Unlock()
 	return es.limit
 }


### PR DESCRIPTION
https://github.com/monochromegane/kaburaya/pull/2 had a bug that calls signal before starting `sync.Cond.Wait()`.
Because it had to unlock mutex before starting wait, signal which was waiting unlock was fired.
Ref: https://github.com/monochromegane/kaburaya/compare/fix-elastic-semaphore-mutex#diff-3ff90a3771cfc187844fab1bd28edcedL29

### Fix

In this fix, `wait`, `signal` and `incrementLimit` are now synchronized by `waitChan`.
And `signalChan` provides simple way instead of `sync.Cond`.

### Performance

Performance has been slightly improved compared to #2.

```
BenchmarkSemaphoreByChannel-8                    2000000               856 ns/op             112 B/op        2 allocs/op
BenchmarkSemaphoreByElasticSemaphore-8           2000000               974 ns/op             360 B/op        6 allocs/op
```

